### PR TITLE
Translation progress indication + warning

### DIFF
--- a/src/App.res
+++ b/src/App.res
@@ -16,13 +16,13 @@ let make = () => {
   let getnumberOfUntranslatedSegments = (data: Source.t) => {
     data
     ->Array.filter(cell =>
-      cell
-      ->Array.get(3)
-      ->Option.map(target => target.value->String.length === 0)
-      ->Option.getOr(false)
+      cell[3]->Option.mapOr(false, target => target.value->String.length === 0)
     )
     ->Array.length
   }
+
+  let numberOfSourceSegments = data->Array.map(cell => cell->Array.get(2))->Array.length
+  let numberOfTranslatedSegments = numberOfSourceSegments - getnumberOfUntranslatedSegments(data)
 
   Hooks.useMultiKeyPress(["Control", "Shift", "?"], () => dispatch(SetDialog(Help)))
   Hooks.useMultiKeyPress(["Control", "Shift", "N"], () => dispatch(SetDialog(CreateTarget)))
@@ -284,6 +284,8 @@ let make = () => {
               value
               onExport
               dispatch
+              numberOfSourceSegments
+              numberOfTranslatedSegments
             />
           )
           ->React.array}

--- a/src/AppState.res
+++ b/src/AppState.res
@@ -87,7 +87,7 @@ let makeInitialState = (localStorage: JSON.t) => {
   },
   history: {past: [], future: []},
   dialog: Closed,
-  mode: Other,
+  mode: Json,
   useDescription: false,
 }
 

--- a/src/AppState.res
+++ b/src/AppState.res
@@ -9,6 +9,7 @@ type dialog =
   | RemoveTarget(string)
   | RemoveSource
   | Help
+  | WarningTranslationIncomplete(int, unit => unit)
 
 type history = {
   past: array<Source.t>,

--- a/src/Dialogs.res
+++ b/src/Dialogs.res
@@ -3,7 +3,11 @@ open ReactUtils
 type shortcut = Simple | Ctrl | CtrlShift
 
 module Shortcut = {
-  let add = (a, b) => <> a {" + "->s} b </>
+  let add = (a, b) => <>
+    a
+    {" + "->s}
+    b
+  </>
   let \"+" = add
   let kc = text => <kbd> {text->s} </kbd>
 
@@ -69,5 +73,22 @@ let make = (~dialog: AppState.dialog, ~data, ~dispatch) => {
       <Shortcut keycap={"Esc"} title="Close dialog" />
       <Shortcut keycap={"Enter"} title="Confirm dialog" />
     </Dialog.Info>
+
+  | WarningTranslationIncomplete(numberOfUntranslatedSegments, ignoreWarningAndExport) => {
+      let title = switch numberOfUntranslatedSegments {
+      | 1 => `There is 1 untranslated segment`
+      | _ => `There are ${numberOfUntranslatedSegments->Int.toString} untranslated segments`
+      }
+      <Dialog.Confirm
+        open_=true
+        title
+        label={"Do you really want to continue the export?"->s}
+        onSubmit={_ => {
+          ignoreWarningAndExport()
+          onClose()
+        }}
+        onClose
+      />
+    }
   }
 }

--- a/src/HeaderCol.res
+++ b/src/HeaderCol.res
@@ -1,3 +1,5 @@
+open ReactUtils
+
 type colType = Id | Description | Source | Target
 
 let getColType = (index, canToggleDescription) => {
@@ -31,10 +33,28 @@ module ExportButtonRow = {
 
 module ActionButtonRow = {
   @react.component
-  let make = (~value, ~onRemoveTarget) =>
+  let make = (~value, ~onRemoveTarget, ~numberOfSourceSegments, ~numberOfTranslatedSegments) => {
+    let translationComplete = numberOfTranslatedSegments === numberOfSourceSegments
     <div className="ActionButtonRow">
+      <div className={`InfoTag ${translationComplete ? "complete" : "incomplete"}`}>
+        <div className="InfoText">
+          {if translationComplete {
+            "Translation complete"->s
+          } else {
+            <>
+              <b>
+                {`${(numberOfSourceSegments - numberOfTranslatedSegments)->Int.toString}${nbsp}`->s}
+              </b>
+              {"of"->s}
+              <b> {`${nbsp}${numberOfSourceSegments->Int.toString}${nbsp}`->s} </b>
+              {"translations missing"->React.string}
+            </>
+          }}
+        </div>
+      </div>
       <IconButton title={"Remove column"} onClick={_evt => onRemoveTarget(value)} icon=#trash />
     </div>
+  }
 }
 
 module IdButtonRow = {
@@ -52,7 +72,16 @@ module IdButtonRow = {
 }
 
 @react.component
-let make = (~index, ~useDescription, ~canToggleDescription, ~value, ~onExport, ~dispatch) => {
+let make = (
+  ~index,
+  ~useDescription,
+  ~canToggleDescription,
+  ~value,
+  ~onExport,
+  ~dispatch,
+  ~numberOfSourceSegments,
+  ~numberOfTranslatedSegments,
+) => {
   let colType = getColType(index, canToggleDescription)
   let onToggleDescriptions = _evt => dispatch(AppState.ToggleUseDescription)
   let onRemoveTarget = column => dispatch(SetDialog(RemoveTarget(column)))
@@ -68,7 +97,7 @@ let make = (~index, ~useDescription, ~canToggleDescription, ~value, ~onExport, ~
       | Target =>
         <>
           <ExportButtonRow value onExport />
-          <ActionButtonRow value onRemoveTarget />
+          <ActionButtonRow value onRemoveTarget numberOfSourceSegments numberOfTranslatedSegments />
         </>
       }}
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -20,7 +20,7 @@ body {
   padding: 20px 0px;
   background-color: #24283a;
   border-radius: 10px;
-  opacity: 1.;
+  opacity: 1;
 }
 
 .ImportOverlay {
@@ -293,4 +293,31 @@ kbd {
   line-height: 1;
   padding: 2px 4px;
   white-space: nowrap;
+}
+
+.InfoTag {
+  padding: 8px;
+  margin: 4px;
+  border: 1px solid rgb(143, 143, 143);
+  border-radius: 5px;
+  box-shadow: 4px 4px 7px silver;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.complete {
+  background-color: #67dba5;
+  font-weight: bold;
+}
+
+.incomplete {
+  background-color: rgba(255, 99, 71, 0.2);
+}
+
+.InfoText {
+  font-size: 14px;
+  font-weight: normal;
+  text-align: center;
 }


### PR DESCRIPTION
- Added a tag in the action row that indicates how many translations are missing
- Added a warning if user tries to export the translation while there are still untranslated segments

@fhammerschmidt Please carefully review my changes of `getColType`. I left a comment and the original code for the review.

![Bildschirmfoto 2024-06-15 um 17 04 46](https://github.com/cca-io/quick-translate/assets/83062199/6b92a4a6-4f41-4daa-9707-59edc0bb07db)
<img width="1041" alt="Bildschirmfoto 2024-06-17 um 08 37 50" src="https://github.com/cca-io/quick-translate/assets/83062199/30794739-4
<img width="1041" alt="Bildschirmfoto 2024-06-17 um 08 37 59" src="https://github.com/cca-io/quick-translate/assets/83062199/02ec78a6-f8a2-41b0-ad5b-f41623c9a1eb">
c76-44f0-bf19-20c21cb04797">
